### PR TITLE
switched back to clang

### DIFF
--- a/Formula/mpich.rb
+++ b/Formula/mpich.rb
@@ -54,8 +54,6 @@ class Mpich < Formula
                           "--enable-shared",
                           "--enable-sharedlibs=gcc-osx",
                           "--with-pm=hydra",
-                          "CC=gcc-#{Formula["gcc"].any_installed_version.major}",
-                          "CXX=g++-#{Formula["gcc"].any_installed_version.major}",
                           "FC=gfortran-#{Formula["gcc"].any_installed_version.major}",
                           "F77=gfortran-#{Formula["gcc"].any_installed_version.major}",
                           "--disable-silent-rules",


### PR DESCRIPTION
Restores initial behavior of using system clang and not gcc-10 as the C compiler

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
